### PR TITLE
Don't remove imports referenced by Javadoc comments.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
       <dependency>
         <groupId>com.github.javaparser</groupId>
         <artifactId>javaparser-core</artifactId>
-        <version>3.6.0</version>
+        <version>3.6.8</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>

--- a/src/main/java/net/revelc/code/impsort/ImpSort.java
+++ b/src/main/java/net/revelc/code/impsort/ImpSort.java
@@ -37,8 +37,17 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.comments.Comment;
+import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
+import com.github.javaparser.javadoc.Javadoc;
+import com.github.javaparser.javadoc.JavadocBlockTag;
+import com.github.javaparser.javadoc.description.JavadocDescription;
+import com.github.javaparser.javadoc.description.JavadocDescriptionElement;
+import com.github.javaparser.javadoc.description.JavadocInlineTag;
+import com.github.javaparser.javadoc.description.JavadocSnippet;
 
 public class ImpSort {
 
@@ -190,6 +199,8 @@ public class ImpSort {
    */
   private static Set<String> extractTokens(CompilationUnit unit) {
     Set<String> tokens = new HashSet<String>();
+
+    // Extract tokens from the java code:
     NodeList<TypeDeclaration<?>> types = unit.getTypes();
     types.forEach(node -> {
       Optional<TokenRange> tokenRange = node.getTokenRange();
@@ -203,6 +214,46 @@ public class ImpSort {
         }
       }
     });
+
+    // Extract referenced class names from javadoc comments:
+    for (Comment comment : unit.getComments()) {
+      if (!(comment instanceof JavadocComment)) {
+        continue;
+      }
+
+      Javadoc javadoc = ((JavadocComment)comment).parse();
+      tokens.addAll(extractTokensFromJavadocDescription(javadoc.getDescription()));
+      for (JavadocBlockTag blockTag : javadoc.getBlockTags()) {
+        tokens.addAll(extractTokensFromJavadocDescription(blockTag.getContent()));
+      }
+    }
+
+    return tokens;
+  }
+
+  private static Set<String> extractTokensFromJavadocDescription(JavadocDescription description) {
+    Set<String> tokens = new HashSet<String>();
+
+    for (JavadocDescriptionElement element : description.getElements()) {
+      if (element instanceof JavadocInlineTag) {
+        // Inline tags are the javadoc tags that look like this: {@link Foo}
+        JavadocInlineTag inlineTag = (JavadocInlineTag) element;
+        for (String token : inlineTag.getContent().split("\\W+")) {
+          if (!token.isEmpty() && Character.isJavaIdentifierStart(token.charAt(0))) {
+            tokens.add(token);
+          }
+        }
+      } else if (element instanceof JavadocSnippet) {
+        // A snippet is anything that isn't an inline tag. "@see" elements become
+        // snippets, so we have to parse these too, even though they tend to contain
+        // a lot of irrelevant tokens.
+        for (String token : element.toText().split("\\W+")) {
+          if (!token.isEmpty() && Character.isJavaIdentifierStart(token.charAt(0))) {
+            tokens.add(token);
+          }
+        }
+      }
+    }
 
     return tokens;
   }

--- a/src/test/java/net/revelc/code/impsort/ImpSortTest.java
+++ b/src/test/java/net/revelc/code/impsort/ImpSortTest.java
@@ -47,11 +47,25 @@ public class ImpSortTest {
     for (Import i : result.getImports()) {
       imports.add(i.getImport());
     }
+
+    assertTrue(imports.contains("com.foo.Type1"));
+    assertTrue(imports.contains("com.foo.Type2"));
+    assertTrue(imports.contains("com.foo.Type3"));
+    assertTrue(imports.contains("com.foo.Type4"));
+    assertTrue(imports.contains("com.foo.Type5"));
+    assertTrue(imports.contains("com.foo.Type6"));
+    assertTrue(imports.contains("com.foo.Type7"));
+    assertTrue(imports.contains("com.foo.Type8"));
+    assertTrue(imports.contains("com.foo.Type9"));
+    assertTrue(imports.contains("com.foo.Type10"));
+
     assertFalse(imports.contains("com.google.common.base.Predicates"));
     assertTrue(imports.contains("com.google.common.collect.ImmutableMap"));
     assertFalse(imports.contains("io.swagger.annotations.ApiOperation"));
     assertFalse(imports.contains("java.util.ArrayList"));
+    assertTrue(imports.contains("java.util.HashMap"));
     assertTrue(imports.contains("java.util.List"));
+    assertTrue(imports.contains("java.util.Map"));
     assertFalse(imports.contains("org.springframework.beans.factory.annotation.Autowired"));
     assertTrue(imports.contains("org.springframework.stereotype.Component"));
     assertFalse(imports.contains("org.junit.Assert.assertEquals"));

--- a/src/test/resources/UnusedImports.java
+++ b/src/test/resources/UnusedImports.java
@@ -14,11 +14,24 @@
 
 package net.revelc.code.imp;
 
+import com.foo.Type1;
+import com.foo.Type2;
+import com.foo.Type3;
+import com.foo.Type4;
+import com.foo.Type5;
+import com.foo.Type6;
+import com.foo.Type7;
+import com.foo.Type8;
+import com.foo.Type9;
+import com.foo.Type10;
+
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableMap;
 import io.swagger.annotations.ApiOperation;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -27,12 +40,32 @@ import static org.junit.Assert.assertFalse;
 
 import static org.junit.Assert.*;
 
+/**
+ * The import of {@link HashMap} should not be stripped away, since it
+ * is used in this comment.
+ */
 @Component
 public class UnusedImports {
     ImmutableMap immutable;
 
+    /**
+     * The following should also not be removed:
+     *
+     * @see Map
+     */
     public List<Integer> getList() {
         assertFalse(false);
         return null;
     }
+
+	/**
+	 * {@link Type1#method()}
+	 * {@link Type2#method(Type3, Type4)}
+	 * {@link #method(Type5, Type6)}
+	 * {@value Type7#field}
+	 * @see Type8#method()
+	 * @see Type9#method(Type10)
+	 */
+	public void foo() {
+	}
 }


### PR DESCRIPTION
This change adds some code to the function that removes unused imports,
to ensure that imports referenced by Javadoc comments (such as {@link
SomeClass}) are not stripped out.

The unit test for removing imports is extended to test this new
functionality.