### PR TITLE
Fix #16: Fixed ArrayIndexOutOfBounds on class with empty javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <formatterConfigFile>src/tools/modified-google-style.xml</formatterConfigFile>
     <github.site.repositoryName>impsort-maven-plugin</github.site.repositoryName>
     <github.site.repositoryOwner>revelc</github.site.repositoryOwner>
-    <javaparser.version>3.15.3</javaparser.version>
+    <javaparser.version>3.15.4</javaparser.version>
     <maven.compiler.release>8</maven.compiler.release>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/test/java/net/revelc/code/impsort/ImpSortTest.java
+++ b/src/test/java/net/revelc/code/impsort/ImpSortTest.java
@@ -118,6 +118,20 @@ public class ImpSortTest {
   }
 
   @Test
+  public void testEmptyJavadoc() throws IOException {
+    Path p =
+        Paths.get(System.getProperty("user.dir"), "src", "test", "resources", "EmptyJavadoc.java");
+    Result result = new ImpSort(StandardCharsets.UTF_8, eclipseDefaults, true, true).parseFile(p);
+    Set<String> imports = new HashSet<>();
+    for (Import i : result.getImports()) {
+      imports.add(i.getImport());
+    }
+
+    assertTrue(imports.contains("java.util.List"));
+    assertTrue(imports.contains("java.util.ArrayList"));
+  }
+
+  @Test
   public void parseGroups() {
     assertEquals(Arrays.asList(new Group("*", 0)), Grouper.parse("*"));
     assertEquals(Arrays.asList(new Group("*", 0)), Grouper.parse(""));

--- a/src/test/resources/EmptyJavadoc.java
+++ b/src/test/resources/EmptyJavadoc.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package some.pkg;
+
+import java.util.List;
+import java.util.ArrayList;
+
+/**
+*/
+public class SomeClass {
+    List something = new ArrayList();
+}


### PR DESCRIPTION
Fixes #16 .

Tested with javaparser:3.15.4-SNAPSHOT. This PR is waiting for tonight release of javaparser:3.15.4