### PR TITLE
Switch to openjdk in travis file, as Xenial does not include oracle java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 


### PR DESCRIPTION
Due recent upgrade of travis servers, which changed default dist to Xenial, the build is failing.
See https://travis-ci.org/revelc/impsort-maven-plugin/builds/606717035

    Expected feature release number in range of 9 to 14, but got: 8
    The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .

Xenial does not include oracle java 8. This PR sets dist attribute explicitly to trusty.