### PR TITLE
Handle empty files and unknown line endings better

### DIFF
--- a/src/main/java/net/revelc/code/impsort/Result.java
+++ b/src/main/java/net/revelc/code/impsort/Result.java
@@ -27,6 +27,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class Result {
@@ -42,6 +43,9 @@ public class Result {
   private final int start;
   private final int stop;
   private final LineEnding lineEnding;
+
+  public static final Result EMPTY_FILE =
+      new Result(null, null, null, 0, 0, "", "", Collections.emptyList(), null);
 
   Result(Path path, Charset sourceEncoding, List<String> fileLines, int start, int stop,
       String originalSection, String newSection, Collection<Import> allImports,

--- a/src/main/java/net/revelc/code/impsort/ex/ImpSortException.java
+++ b/src/main/java/net/revelc/code/impsort/ex/ImpSortException.java
@@ -21,7 +21,6 @@ public class ImpSortException extends IOException {
 
   public enum Reason {
     // @formatter:off
-    EMPTY_FILE("empty file"),
     UNKNOWN_LINE_ENDING("unknown line ending"),
     UNABLE_TO_PARSE("unable to successfully parse the Java file"),
     PARTIAL_PARSE("the Java file contained parse errors")


### PR DESCRIPTION
* Return an empty result if the file is empty to skip the file
* Only throw an exception when line ending is unknown, if the line
  ending configuration is set to KEEP
* When reading all lines from the buffer into a list, do not depend on
  the previously detected line endings, and instead read all lines
  as-is, regardless of line ending previously detected