### PR TITLE
Update plugins/dependencies and improve output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <formatterConfigFile>src/tools/modified-google-style.xml</formatterConfigFile>
     <github.site.repositoryName>impsort-maven-plugin</github.site.repositoryName>
     <github.site.repositoryOwner>revelc</github.site.repositoryOwner>
-    <javaparser.version>3.18.0</javaparser.version>
+    <javaparser.version>3.19.0</javaparser.version>
     <maven.compiler.release>8</maven.compiler.release>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -107,7 +107,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.13.1</version>
+        <version>4.13.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
@@ -191,7 +191,7 @@
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>2.12.0</version>
+          <version>2.13.1</version>
           <configuration>
             <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
             <createBackupFile>false</createBackupFile>
@@ -263,7 +263,7 @@
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>impsort-maven-plugin</artifactId>
-          <version>1.4.1</version>
+          <version>1.5.0</version>
           <configuration>
             <groups>java.,javax.,org.,com.</groups>
           </configuration>
@@ -271,12 +271,19 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.2</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>8.41</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.0.4</version>
+          <version>4.2.0</version>
           <configuration>
             <xmlOutput>true</xmlOutput>
             <effort>Max</effort>

--- a/src/main/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojo.java
+++ b/src/main/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojo.java
@@ -260,7 +260,7 @@ abstract class AbstractImpSortMojo extends AbstractMojo {
     Charset encoding = Charset.forName(sourceEncoding);
 
     LanguageLevel langLevel = getLanguageLevel(compliance);
-    getLog().info("Using compiler compliance level: " + langLevel.toString());
+    getLog().debug("Using compiler compliance level: " + langLevel.toString());
     ImpSort impSort = new ImpSort(encoding, grouper, removeUnused, treatSamePackageAsUnused,
         lineEnding, langLevel);
     AtomicLong numAlreadySorted = new AtomicLong(0);
@@ -315,11 +315,9 @@ abstract class AbstractImpSortMojo extends AbstractMojo {
     long minutes = totalTime.getSeconds() / 60;
     long seconds = totalTime.getSeconds() - minutes * 60;
     long millis = totalTime.getNano() / 1_000_000;
-    String fmt = "%22s: %" + Long.toString(total).length() + "d";
-    getLog().info(String.format(fmt + " in %02d:%02d.%03d", "Total Files Processed", total, minutes,
-        seconds, millis));
-    getLog().info(String.format(fmt, "Already Sorted", numAlreadySorted.get()));
-    getLog().info(String.format(fmt, "Needed Sorting", numProcessed.get()));
+    getLog().info(String.format(
+        "Processed %d files in %02d:%02d.%03d (Already Sorted: %d, Needed Sorting: %d)", total,
+        minutes, seconds, millis, numAlreadySorted.get(), numProcessed.get()));
 
     // check for failures during processing
     if (failure != null) {


### PR DESCRIPTION
* Update build plugins to latest
* Update dependencies to latest
* Lower output message for compiler compliance to debug
* Reduce output lines for sorting/checking to a single line

This fixes #40