### PR TITLE
Add test case for preview features and bump deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,16 +80,17 @@
     <formatterConfigFile>src/tools/modified-google-style.xml</formatterConfigFile>
     <github.site.repositoryName>impsort-maven-plugin</github.site.repositoryName>
     <github.site.repositoryOwner>revelc</github.site.repositoryOwner>
-    <javaparser.version>3.19.0</javaparser.version>
+    <javaparser.version>3.20.2</javaparser.version>
     <maven.compiler.release>8</maven.compiler.release>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <!-- skip standard site deployment, because site is deployed using github plugin instead -->
     <maven.site.deploy.skip>true</maven.site.deploy.skip>
-    <maven.tools-version>3.6.3</maven.tools-version>
-    <mavenPluginToolsVersion>3.6.0</mavenPluginToolsVersion>
+    <maven.tools-version>3.8.1</maven.tools-version>
+    <mavenPluginToolsVersion>3.6.1</mavenPluginToolsVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <projectInfoReportsVersion>3.1.1</projectInfoReportsVersion>
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
   </properties>
   <dependencyManagement>
@@ -102,7 +103,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>30.1-jre</version>
+        <version>30.1.1-jre</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -245,7 +246,7 @@
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.13.0</version>
+          <version>2.15.0</version>
           <configuration>
             <compilerCompliance>${maven.compiler.source}</compilerCompliance>
             <compilerSource>${maven.compiler.source}</compilerSource>
@@ -263,7 +264,7 @@
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>impsort-maven-plugin</artifactId>
-          <version>1.5.0</version>
+          <version>1.6.0</version>
           <configuration>
             <groups>java.,javax.,org.,com.</groups>
           </configuration>
@@ -276,7 +277,7 @@
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>8.41</version>
+              <version>8.42</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -291,6 +292,16 @@
             <includeTests>true</includeTests>
             <maxRank>20</maxRank>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>${mavenPluginToolsVersion}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>${projectInfoReportsVersion}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -435,7 +446,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>${projectInfoReportsVersion}</version>
       </plugin>
     </plugins>
   </reporting>

--- a/src/main/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojo.java
+++ b/src/main/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojo.java
@@ -207,6 +207,11 @@ abstract class AbstractImpSortMojo extends AbstractMojo {
   /**
    * Sets the Java source compliance level (e.g. 1.0, 1.5, 1.7, 8, 9, 11, etc.)
    *
+   * <p>
+   * To enable support a specific Java version, set the version here. If you require the use of
+   * preview features, append <code>_PREVIEW</code> to the version. For example, to use Java 14,
+   * with preview features, set this to <code>14_PREVIEW</code>.
+   *
    * @since 1.5.0
    */
   @Parameter(alias = "compliance", property = "impsort.compliance",
@@ -365,7 +370,7 @@ abstract class AbstractImpSortMojo extends AbstractMojo {
       return LanguageLevel.POPULAR;
     }
     String langLevel = "";
-    String v = compliance.trim();
+    String v = compliance.toUpperCase().trim(); // upper case for "PREVIEW" language levels
     if (v.matches("^1[.][01234]$")) {
       langLevel = "JAVA_" + v.replace(".", "_");
     } else if (v.matches("^1[.][56789]$")) {

--- a/src/test/java/net/revelc/code/impsort/ImpSortTest.java
+++ b/src/test/java/net/revelc/code/impsort/ImpSortTest.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 
 import org.junit.Test;
 
+import com.github.javaparser.ParserConfiguration.LanguageLevel;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.expr.Name;
 import com.google.common.primitives.Bytes;
@@ -217,5 +218,24 @@ public class ImpSortTest {
     List<String> lines = Files.readAllLines(output);
     assertEquals(1, lines.stream().filter(line -> line.equals(" * Some comment")).count());
   }
+
+  @Test
+  public void testJava13PreviewFeatures() throws IOException {
+    Path p =
+        Paths.get(System.getProperty("user.dir"), "src", "test", "resources", "Java13Preview.java");
+    Result result = new ImpSort(StandardCharsets.UTF_8, eclipseDefaults, true, true,
+        LineEnding.AUTO, LanguageLevel.JAVA_13_PREVIEW).parseFile(p);
+
+    Path output = File.createTempFile("java13preview", null, new File("target")).toPath();
+    result.saveSorted(output);
+
+    List<String> lines = Files.readAllLines(output);
+    // check that text block was parsed and hasn't been mangled
+    assertEquals(2, lines.stream().filter(line -> line.contains("\"\"\"")).count());
+    // check that record text was parsed and hasn't been mangled
+    assertEquals(1,
+        lines.stream().filter(line -> line.contains("public static record Person")).count());
+  }
+
 }
 

--- a/src/test/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojoTest.java
+++ b/src/test/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojoTest.java
@@ -53,6 +53,9 @@ public class AbstractImpSortMojoTest {
     assertThrows(IllegalArgumentException.class, () -> getLanguageLevel("1.12"));
     assertThrows(IllegalArgumentException.class, () -> getLanguageLevel("1.13"));
     assertThrows(IllegalArgumentException.class, () -> getLanguageLevel("1.14"));
+    // make sure preview works
+    assertSame(LanguageLevel.JAVA_14_PREVIEW, getLanguageLevel("14_PREVIEW"));
+    assertSame(LanguageLevel.JAVA_16_PREVIEW, getLanguageLevel("16_PREVIEW"));
   }
 
 }

--- a/src/test/resources/Java13Preview.java
+++ b/src/test/resources/Java13Preview.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public class Java13Preview {
+
+  public void hello() {
+    String s = """
+        hello world
+        """;
+  }
+
+  public static record Person(String name, String occupation) {
+  }
+}


### PR DESCRIPTION
* Add a test case for Java 13 preview features, for #44 and #45
* Bump dependency and plugin versions
* Ensure reporting plugins for site build are properly versioned via the
  pluginManagement section
* Make compliance option uppercase when comparing, so it gets the
  correct LanguageLevel for `PREVIEW` versions from the javaparser
  library