### PR TITLE
Bump javaparser to 3.22.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <formatterConfigFile>src/tools/modified-google-style.xml</formatterConfigFile>
     <github.site.repositoryName>impsort-maven-plugin</github.site.repositoryName>
     <github.site.repositoryOwner>revelc</github.site.repositoryOwner>
-    <javaparser.version>3.22.0</javaparser.version>
+    <javaparser.version>3.22.1</javaparser.version>
     <maven.compiler.release>8</maven.compiler.release>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -264,7 +264,7 @@
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>impsort-maven-plugin</artifactId>
-          <version>1.6.0</version>
+          <version>1.6.1</version>
           <configuration>
             <groups>java.,javax.,org.,com.</groups>
           </configuration>


### PR DESCRIPTION
Fix issue identified in comment (overzealous record parsing)
https://github.com/revelc/impsort-maven-plugin/issues/44#issuecomment-840756202