### PR TITLE
[pom] Add empty relativePath to force parent check in .m2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
     <version>23</version>
+    <relativePath />
   </parent>
   <groupId>net.revelc.code</groupId>
   <artifactId>impsort-maven-plugin</artifactId>


### PR DESCRIPTION
parent will never be up one root.  This is best practice.  While most won't see the issue, those like myself that have a pom one above for specific need will continually get warnings that the project is misconfigured.