### PR TITLE
Migrate tests to modern JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,9 +107,9 @@
         <version>30.1.1-jre</version>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.2</version>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>5.8.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
@@ -163,8 +163,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/net/revelc/code/impsort/ImpSortTest.java
+++ b/src/test/java/net/revelc/code/impsort/ImpSortTest.java
@@ -14,10 +14,10 @@
 
 package net.revelc.code.impsort;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,7 +35,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.github.javaparser.ParserConfiguration.LanguageLevel;
 import com.github.javaparser.ast.PackageDeclaration;

--- a/src/test/java/net/revelc/code/impsort/LineEndingEdgeCasesTest.java
+++ b/src/test/java/net/revelc/code/impsort/LineEndingEdgeCasesTest.java
@@ -14,10 +14,10 @@
 package net.revelc.code.impsort;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,9 +25,8 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import net.revelc.code.impsort.ex.ImpSortException;
 import net.revelc.code.impsort.ex.ImpSortException.Reason;
@@ -40,16 +39,15 @@ public class LineEndingEdgeCasesTest {
   private static Grouper eclipseDefaults =
       new Grouper("java.,javax.,org.,com.", "", false, false, true);
 
-  @Rule
-  public TemporaryFolder folder =
-      new TemporaryFolder(new File(System.getProperty("user.dir"), "target"));
+  @TempDir
+  public File folder;
 
   /**
    * Test successfully parsing empty file (zero bytes).
    */
   @Test
   public void testEmptyFile() throws IOException {
-    Path p = folder.newFile("EmptyFile.java").toPath();
+    Path p = new File(folder, "EmptyFile.java").toPath();
     Files.write(p, new byte[0]);
     Result actual = new ImpSort(UTF_8, eclipseDefaults, true, true, LineEnding.AUTO).parseFile(p);
     assertEquals(Result.EMPTY_FILE, actual);
@@ -64,7 +62,7 @@ public class LineEndingEdgeCasesTest {
   public void testFileKeepWithoutLineEnding() throws IOException {
     String s =
         "import java.lang.System;public class FileWithoutNewline{public static void main(String[] args){System.out.println(\"Hello, world!\");}}";
-    Path p = folder.newFile("FileWithoutLineEnding.java").toPath();
+    Path p = new File(folder, "FileWithoutLineEnding.java").toPath();
     Files.write(p, s.getBytes(UTF_8));
     ImpSortException e = assertThrows(ImpSortException.class,
         () -> new ImpSort(UTF_8, eclipseDefaults, true, true, LineEnding.KEEP).parseFile(p));
@@ -79,7 +77,7 @@ public class LineEndingEdgeCasesTest {
   public void testFileAutoWithoutLineEnding() throws IOException {
     String s =
         "import java.lang.System;public class FileWithoutNewline{public static void main(String[] args){System.out.println(\"Hello, world!\");}}";
-    Path p = folder.newFile("FileWithoutLineEnding.java").toPath();
+    Path p = new File(folder, "FileWithoutLineEnding.java").toPath();
     Files.write(p, s.getBytes(UTF_8));
     Result result = new ImpSort(UTF_8, eclipseDefaults, true, true, LineEnding.AUTO).parseFile(p);
     assertEquals(1, result.getImports().size());
@@ -97,7 +95,7 @@ public class LineEndingEdgeCasesTest {
   public void testPartiallyParsedFile() throws IOException {
     String s = "public class InvalidFile {\n" + "    public static void main(String[] args) {\n"
         + "        System.out.println(\"Hello, world!\")\n" + "    }\n" + "}\n";
-    Path p = folder.newFile("InvalidFile.java").toPath();
+    Path p = new File(folder, "InvalidFile.java").toPath();
     Files.write(p, s.getBytes(UTF_8));
     ImpSortException e = assertThrows(ImpSortException.class,
         () -> new ImpSort(UTF_8, eclipseDefaults, true, true, LineEnding.AUTO).parseFile(p));
@@ -111,7 +109,7 @@ public class LineEndingEdgeCasesTest {
   @Test
   public void testInvalidFile() throws IOException {
     String s = "\0\n\n";
-    Path p = folder.newFile("NoResult.java").toPath();
+    Path p = new File(folder, "NoResult.java").toPath();
     Files.write(p, s.getBytes(UTF_8));
     ImpSortException e = assertThrows(ImpSortException.class,
         () -> new ImpSort(UTF_8, eclipseDefaults, true, true, LineEnding.AUTO).parseFile(p));
@@ -125,7 +123,7 @@ public class LineEndingEdgeCasesTest {
    */
   @Test
   public void testMissingFile() throws IOException {
-    Path p = new File(folder.getRoot().getAbsolutePath(), "MissingFile.java").toPath();
+    Path p = new File(folder.getAbsolutePath(), "MissingFile.java").toPath();
     NoSuchFileException e = assertThrows(NoSuchFileException.class,
         () -> new ImpSort(UTF_8, eclipseDefaults, true, true, LineEnding.AUTO).parseFile(p));
     assertEquals(p.toString(), e.getMessage());

--- a/src/test/java/net/revelc/code/impsort/LineEndingTest.java
+++ b/src/test/java/net/revelc/code/impsort/LineEndingTest.java
@@ -13,9 +13,9 @@
  */
 package net.revelc.code.impsort;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for {@link LineEnding}.

--- a/src/test/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojoTest.java
+++ b/src/test/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojoTest.java
@@ -15,10 +15,10 @@
 package net.revelc.code.impsort.maven.plugin;
 
 import static net.revelc.code.impsort.maven.plugin.AbstractImpSortMojo.getLanguageLevel;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.github.javaparser.ParserConfiguration.LanguageLevel;
 


### PR DESCRIPTION
The project currently uses the outdated JUnit 4.13.2. In order to make it easier to write tests and easier for future contributors to easily start working with the project, this path migrates the test suite to the modern JUnit Jupiter.

Changes:
- The `junit:junit:4.13.2` dependency was replaced with `org.junit.jupiter:junit-jupiter:5.8.1`.
- The `org.junit.jupiter.api.Test` annotation was used as a drop-in replacement for `org.junit.Test`.
- The static imports from `org.junit.jupiter.api.Assertions` were used as drop-in replacements for the static imports from `org.junit.Assert`.
- `LineEndingEdgeCasesTest` was rewritten to use JUnit Jupiter's `org.junit.jupiter.api.io.TempDir` annotation instead of JUnit 4's `org.junit.rules.TemporaryFolder`.