### PR TITLE
Set surefire's tempdir to target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <projectInfoReportsVersion>3.1.2</projectInfoReportsVersion>
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
+    <surefire.version>3.0.0-M5</surefire.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -420,7 +421,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
         <configuration>
           <argLine>-Djava.io.tmpdir="${project.build.directory}"</argLine>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -107,11 +107,6 @@
         <version>30.1.1-jre</version>
       </dependency>
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <version>5.8.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-core</artifactId>
         <version>${maven.tools-version}</version>
@@ -130,6 +125,11 @@
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
         <version>3.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>5.8.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -434,6 +434,14 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M5</version>
+        <configuration>
+          <argLine>-Djava.io.tmpdir="${project.build.directory}"</argLine>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This patch follows up on the review given for #51 and uses `maven-surefire-plugin`'s configuration to set the tempdir to target and
restore the behavior change introduced in that PR.

Note:
This fix will only effect running the test via maven. If the test is manually run (e.g., from an IDE), `java.io.tmpdir` should be overridden manually too.