### PR TITLE
Bump minimum JDK to 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <mailingList />
   </mailingLists>
   <prerequisites>
-    <maven>3.3.9</maven>
+    <maven>3.5.0</maven>
   </prerequisites>
   <scm>
     <connection>scm:git:https://github.com/revelc/impsort-maven-plugin.git</connection>
@@ -81,13 +81,13 @@
     <formatterConfigFile>src/tools/modified-google-style.xml</formatterConfigFile>
     <github.site.repositoryName>impsort-maven-plugin</github.site.repositoryName>
     <github.site.repositoryOwner>revelc</github.site.repositoryOwner>
-    <javaparser.version>3.23.0</javaparser.version>
-    <maven.compiler.release>8</maven.compiler.release>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <javaparser.version>3.23.1</javaparser.version>
+    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <!-- skip standard site deployment, because site is deployed using github plugin instead -->
     <maven.site.deploy.skip>true</maven.site.deploy.skip>
-    <maven.tools-version>3.8.2</maven.tools-version>
+    <maven.tools-version>3.8.3</maven.tools-version>
     <mavenPluginToolsVersion>3.6.1</mavenPluginToolsVersion>
     <minimalJavaBuildVersion>11</minimalJavaBuildVersion>
     <minimalMavenBuildVersion>3.5.0</minimalMavenBuildVersion>
@@ -283,7 +283,7 @@
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>9.0</version>
+              <version>9.0.1</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
* Make plugin require at least JDK 11 and Maven 3.5 to run
* Bump javaparser, maven tools, and checkstyle to latest