### PR TITLE
[cache] Change 'toAbsolutePath().normalize()' to 'toFile().getCanonicalPath()'

### DIFF
--- a/src/main/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojo.java
+++ b/src/main/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojo.java
@@ -278,7 +278,7 @@ abstract class AbstractImpSortMojo extends AbstractMojo {
         try {
           byte[] buf = Files.readAllBytes(path);
           String newHash = getHash(buf);
-          String key = path.toAbsolutePath().normalize().toString();
+          String key = path.toFile().getCanonicalPath();
           String prvHash = hashCache.getProperty(key);
           if (prvHash != null && prvHash.equals(newHash)) {
             numAlreadySorted.getAndIncrement();


### PR DESCRIPTION
to remove unnecessary disk path fixing #58 

Current usage ends up with caching showing full system path from root drive such as C drive.  That is unnecessary for the caching solution.  Change here to same logic used in formatter maven plugin so that it picks up from root of project only.