### PR TITLE
Plexus Utils is and never was part of Maven core in Maven3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,10 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <scope>provided</scope>
@@ -159,11 +163,6 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This is remnant from Maven2 and worked in Maven3 due Maven3 backward compatibility layer toward Maven2. This is getting removed in Maven 3.9.0 and 4.

Plexus Utils is a compile scope dependency of the plugin.

Fixes #64 