### PR TITLE
Bump java-parser to 3.25.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <formatterConfigFile>src/tools/modified-google-style.xml</formatterConfigFile>
     <github.site.repositoryName>impsort-maven-plugin</github.site.repositoryName>
     <github.site.repositoryOwner>revelc</github.site.repositoryOwner>
-    <javaparser.version>3.25.3</javaparser.version>
+    <javaparser.version>3.25.4</javaparser.version>
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
This fixes a bug when `sealed` is used in an attribute

- Fixes #72

Changelog: https://github.com/javaparser/javaparser/releases/tag/javaparser-parent-3.25.4