### PR TITLE
[pom] Add default descriptor / helpmojo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,24 @@
           <argLine>-Djava.io.tmpdir="${project.build.directory}"</argLine>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>help-goal</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <reporting>


### PR DESCRIPTION
Over on javaparser, noticed this ticket https://github.com/javaparser/javaparser/issues/3309.

This indicated this did not work with maven plugins but we are one, so I tried to check help.  Noticed we had plugin management and m2e data for same but failed to do this at all.  Added it and have tested it, works as expected.  Don't recall if some reason it was not here but its generally best practice to offer 'help' at very least.