### PR TITLE
ignore parse errors below imports (to allow the plugin to work with Java > 18)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <formatterConfigFile>src/tools/modified-google-style.xml</formatterConfigFile>
     <github.site.repositoryName>impsort-maven-plugin</github.site.repositoryName>
     <github.site.repositoryOwner>revelc</github.site.repositoryOwner>
-    <javaparser.version>3.25.5</javaparser.version>
+    <javaparser.version>3.25.7</javaparser.version>
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/src/main/java/net/revelc/code/impsort/ParseProblemFilter.java
+++ b/src/main/java/net/revelc/code/impsort/ParseProblemFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.revelc.code.impsort;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.github.javaparser.JavaToken;
+import com.github.javaparser.Position;
+import com.github.javaparser.Problem;
+import com.github.javaparser.TokenRange;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.TypeDeclaration;
+
+public class ParseProblemFilter {
+
+  /**
+   * Only return problems before the first top level decleration. All other problems might for
+   * example be caused be a newer Java version but should have no impact on import sorting.
+   */
+  public static List<Problem> getImportRelevantProblems(CompilationUnit unit,
+      List<Problem> problems) {
+    Optional<Position> firstTopLevelBegin = unit.getTypes().stream().map(TypeDeclaration::getBegin)
+        .filter(Optional::isPresent).map(Optional::get).sorted().findFirst();
+    if (firstTopLevelBegin.isEmpty()) {
+      // should not happen but let's simply give up and return the problems as they are
+      return problems;
+    } else {
+      return problems.stream()
+          .filter(p -> p.getLocation().map(TokenRange::getBegin).flatMap(JavaToken::getRange)
+              .map(r -> r.isBefore(firstTopLevelBegin.orElseThrow())).orElse(Boolean.FALSE))
+          .collect(Collectors.toList());
+    }
+  }
+}

--- a/src/main/java/net/revelc/code/impsort/Result.java
+++ b/src/main/java/net/revelc/code/impsort/Result.java
@@ -28,6 +28,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import com.github.javaparser.Position;
+import com.github.javaparser.Problem;
+
 public class Result {
 
   private Boolean isSorted;
@@ -41,13 +44,15 @@ public class Result {
   private final int start;
   private final int stop;
   private final LineEnding lineEnding;
+  private List<Problem> problems;
+  private List<Problem> reportableProblems;
 
   public static final Result EMPTY_FILE =
-      new Result(null, null, null, 0, 0, "", "", Collections.emptyList(), null);
+      new Result(null, null, null, 0, 0, "", "", Collections.emptyList(), null, null, null);
 
   Result(Path path, Charset sourceEncoding, List<String> fileLines, int start, int stop,
       String originalSection, String newSection, Collection<Import> allImports,
-      LineEnding lineEnding) {
+      LineEnding lineEnding, List<Problem> problems, List<Problem> reportableProblems) {
     this.path = path;
     this.sourceEncoding = sourceEncoding;
     this.originalSection = originalSection;
@@ -57,6 +62,8 @@ public class Result {
     this.start = start;
     this.stop = stop;
     this.lineEnding = lineEnding;
+    this.problems = problems;
+    this.reportableProblems = reportableProblems;
   }
 
   public boolean isSorted() {
@@ -109,4 +116,21 @@ public class Result {
     return buf;
   }
 
+  public Position getFirstLineContaining(String string) {
+    for (int i = 0; i < fileLines.size(); i++) {
+      if (fileLines.get(i).contains(string)) {
+        return new Position(i, 0);
+      }
+    }
+
+    throw new IllegalStateException("Can't find '" + string + "'!");
+  }
+
+  public List<Problem> getProblems() {
+    return Collections.unmodifiableList(problems);
+  }
+
+  public List<Problem> getReportableProblems() {
+    return Collections.unmodifiableList(reportableProblems);
+  }
 }

--- a/src/test/java/net/revelc/code/impsort/ImpSortTest.java
+++ b/src/test/java/net/revelc/code/impsort/ImpSortTest.java
@@ -224,7 +224,7 @@ public class ImpSortTest {
     Path p =
         Paths.get(System.getProperty("user.dir"), "src", "test", "resources", "Java14Preview.java");
     Result result = new ImpSort(StandardCharsets.UTF_8, eclipseDefaults, true, true,
-        LineEnding.AUTO, LanguageLevel.JAVA_14_PREVIEW).parseFile(p);
+        LineEnding.AUTO, LanguageLevel.JAVA_14_PREVIEW, false).parseFile(p);
 
     Path output = File.createTempFile("java14preview", null, new File("target")).toPath();
     result.saveSorted(output);
@@ -237,5 +237,31 @@ public class ImpSortTest {
         lines.stream().filter(line -> line.contains("public record Java14Preview")).count());
   }
 
+  @Test
+  public void testJava21RecordDeconstruction() throws IOException {
+    Path p = Paths.get(System.getProperty("user.dir"), "src", "test", "resources",
+        "Java21RecordDeconstruction.java");
+
+    // unfortunately Java 17 Preview is the most recently supported level
+    Result result = new ImpSort(StandardCharsets.UTF_8, eclipseDefaults, true, true,
+        LineEnding.AUTO, LanguageLevel.JAVA_17_PREVIEW, true).parseFile(p);
+
+    Path output =
+        File.createTempFile("java21record-deconstruction", null, new File("target")).toPath();
+    result.saveSorted(output);
+
+    List<String> lines = Files.readAllLines(output);
+    // check that record text was parsed and hasn't been mangled
+    assertEquals(1,
+        lines.stream()
+            .filter(
+                line -> line.contains("public record Java21RecordDeconstruction(Point point) {"))
+            .count());
+    // check that the deconstruction hasn't been mangled (even if not parsable)
+    assertEquals(1,
+        lines.stream()
+            .filter(line -> line.contains("obj instanceof Java21RecordDeconstruction(Point point)"))
+            .count());
+  }
 }
 

--- a/src/test/java/net/revelc/code/impsort/ImpSortTest.java
+++ b/src/test/java/net/revelc/code/impsort/ImpSortTest.java
@@ -238,25 +238,25 @@ public class ImpSortTest {
   }
 
   @Test
-  public void testJava21RecordDeconstruction() throws IOException {
+  public void testIgnoreParseErrorsBelowImports() throws IOException {
     Path p = Paths.get(System.getProperty("user.dir"), "src", "test", "resources",
         "Java21RecordDeconstruction.java");
 
-    // unfortunately Java 17 Preview is the most recently supported level
     Result result = new ImpSort(StandardCharsets.UTF_8, eclipseDefaults, true, true,
-        LineEnding.AUTO, LanguageLevel.JAVA_17_PREVIEW, true).parseFile(p);
+        LineEnding.AUTO, LanguageLevel.JAVA_18, true).parseFile(p);
+
+    assertTrue(result.getReportableProblems().isEmpty());
+    assertEquals(1,
+        result.getProblems().stream().map(ParseProblemFilter::toRange)
+            .filter(problemRange -> problemRange.orElseThrow()
+                .isAfter(result.getFirstLineContaining("public record Java21RecordDeconstruction")))
+            .count());
 
     Path output =
         File.createTempFile("java21record-deconstruction", null, new File("target")).toPath();
     result.saveSorted(output);
 
     List<String> lines = Files.readAllLines(output);
-    // check that record text was parsed and hasn't been mangled
-    assertEquals(1,
-        lines.stream()
-            .filter(
-                line -> line.contains("public record Java21RecordDeconstruction(Point point) {"))
-            .count());
     // check that the deconstruction hasn't been mangled (even if not parsable)
     assertEquals(1,
         lines.stream()

--- a/src/test/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojoTest.java
+++ b/src/test/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojoTest.java
@@ -36,7 +36,9 @@ public class AbstractImpSortMojoTest {
 
     assertSame(LanguageLevel.POPULAR, getLanguageLevel(null, true));
     assertSame(LanguageLevel.POPULAR, getLanguageLevel("", true));
-    assertSame(LanguageLevel.POPULAR, getLanguageLevel("JAVA_11", true));
+    assertSame(LanguageLevel.POPULAR, getLanguageLevel("42", true));
+
+    assertSame(LanguageLevel.JAVA_12, getLanguageLevel("12", true));
 
     var prefix = "JAVA_";
     var previewSuffix = "_PREVIEW";

--- a/src/test/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojoTest.java
+++ b/src/test/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojoTest.java
@@ -31,8 +31,13 @@ public class AbstractImpSortMojoTest {
 
   @Test
   public void testLanguageLevel() {
-    assertSame(LanguageLevel.POPULAR, getLanguageLevel(null));
-    assertSame(LanguageLevel.POPULAR, getLanguageLevel(""));
+    assertSame(LanguageLevel.POPULAR, getLanguageLevel(null, false));
+    assertSame(LanguageLevel.POPULAR, getLanguageLevel("", false));
+
+    assertSame(LanguageLevel.POPULAR, getLanguageLevel(null, true));
+    assertSame(LanguageLevel.POPULAR, getLanguageLevel("", true));
+    assertSame(LanguageLevel.POPULAR, getLanguageLevel("JAVA_11", true));
+
     var prefix = "JAVA_";
     var previewSuffix = "_PREVIEW";
     // only these can be represented using single digit or 1.<digit>, as in Java 5 or Java 1.5
@@ -46,14 +51,14 @@ public class AbstractImpSortMojoTest {
       if (version.length() == 1) {
         // check that the versions that can be represented by either X or 1.X are the same
         assertTrue(expectedOneDotOrSingle.remove(version), "Unexpectedly saw " + version);
-        assertSame(level, getLanguageLevel("1." + version));
+        assertSame(level, getLanguageLevel("1." + version, false));
       } else if (!version.contains(".") && !version.contains(previewSuffix)) {
         // make sure versions above Java 9 can't be represented as 1.X, as in 1.10
         final var v = version;
-        assertThrows(IllegalArgumentException.class, () -> getLanguageLevel("1." + v));
+        assertThrows(IllegalArgumentException.class, () -> getLanguageLevel("1." + v, false));
       }
       // basic check to make sure our getter method returns the correct level
-      assertSame(level, getLanguageLevel(version));
+      assertSame(level, getLanguageLevel(version, false));
     });
     assertTrue(expectedOneDotOrSingle.isEmpty(), "Did not encounter " + expectedOneDotOrSingle);
   }

--- a/src/test/resources/Java21RecordDeconstruction.java
+++ b/src/test/resources/Java21RecordDeconstruction.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package some.pkg;
+
+import java.awt.Point;
+
+public record Java21RecordDeconstruction(Point point) {
+
+	public static int getX(Object obj) {
+		if (obj instanceof Java21RecordDeconstruction(Point point)) {
+			return point.x;
+		} else {
+			throw new IllegalArgumentException();
+		}
+	}
+}

--- a/src/test/resources/Java21RecordDeconstruction.java
+++ b/src/test/resources/Java21RecordDeconstruction.java
@@ -17,11 +17,11 @@ import java.awt.Point;
 
 public record Java21RecordDeconstruction(Point point) {
 
-	public static int getX(Object obj) {
-		if (obj instanceof Java21RecordDeconstruction(Point point)) {
-			return point.x;
-		} else {
-			throw new IllegalArgumentException();
-		}
-	}
+  public static int getX(Object obj) {
+    if (obj instanceof Java21RecordDeconstruction(Point point)) {
+      return point.x;
+    } else {
+      throw new IllegalArgumentException();
+    }
+  }
 }


### PR DESCRIPTION
- unfortunately the used https://github.com/javaparser/javaparser is stuck with Java 18 (in latest version 3.25.7)
- but it turned out that even in case of a parse error somewhere in a top level declaration the imports are correctly parsed and available
- introduced `<ignoreIrrelevantParseErrors>` which is `false` for now but allows to ignore the parse errors in the top level declarations (they shouldn't affect import sorting at all)
- introduced a test case with Java 21 record deconstruction