### PR TITLE
chore: Bump javaparser version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <formatter.configFile>src/tools/modified-google-style.xml</formatter.configFile>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.outputTimestamp>2026-01-10T19:11:06Z</project.build.outputTimestamp>
-    <version.javaparser>3.28.0</version.javaparser>
+    <version.javaparser>3.28.1</version.javaparser>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Hi team,

the javaparser team released [a new patch version](https://github.com/javaparser/javaparser/releases/tag/javaparser-parent-3.28.1) that contains this fix: https://github.com/javaparser/javaparser/pull/4968.

This should fix the issue mentioned by @nils-christian here: https://github.com/revelc/impsort-maven-plugin/issues/159#issuecomment-3738301111 and also @kjoer.

I built a local snapshot version and verified that I could sort a file that previously caused an error, because a switch statement could not be parsed correctly.

fixes  #172 

Edit: Sorry, I missed the dependabot PR that duplicates this: https://github.com/revelc/impsort-maven-plugin/pull/177. 