### PR TITLE
Add joinStaticGroups option

### DIFF
--- a/src/main/java/net/revelc/code/impsort/Grouper.java
+++ b/src/main/java/net/revelc/code/impsort/Grouper.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -34,14 +33,21 @@ public final class Grouper {
   private final List<Group> staticGroups;
   private final boolean staticAfter;
   private final boolean joinStaticWithNonStatic;
+  private final boolean joinStaticGroups;
   private final boolean breadthFirstStatic;
 
   public Grouper(String groups, String staticGroups, boolean staticAfter,
       boolean joinStaticWithNonStatic, boolean breadthFirstStatic) {
+    this(groups, staticGroups, staticAfter, joinStaticWithNonStatic, false, breadthFirstStatic);
+  }
+
+  public Grouper(String groups, String staticGroups, boolean staticAfter,
+      boolean joinStaticWithNonStatic, boolean joinStaticGroups, boolean breadthFirstStatic) {
     this.groups = Collections.unmodifiableList(parse(groups));
     this.staticGroups = parse(staticGroups);
     this.staticAfter = staticAfter;
     this.joinStaticWithNonStatic = joinStaticWithNonStatic;
+    this.joinStaticGroups = joinStaticGroups;
     this.breadthFirstStatic = breadthFirstStatic;
   }
 
@@ -132,22 +138,26 @@ public final class Grouper {
     Map<Integer, ArrayList<Import>> first = getStaticAfter() ? nonStaticImports : staticImports;
     Map<Integer, ArrayList<Import>> second = getStaticAfter() ? staticImports : nonStaticImports;
 
-    AtomicBoolean firstGroup = new AtomicBoolean(true);
-    Consumer<ArrayList<Import>> consumer = grouping -> {
-      if (!firstGroup.getAndSet(false)) {
-        sb.append(eol);
-      }
-      grouping.forEach(imp -> sb.append(imp).append(eol));
-    };
-    first.values().forEach(consumer);
+    emitSection(sb, first, first == staticImports, eol);
     if (!getJoinStaticWithNonStatic() && !first.isEmpty() && !second.isEmpty()) {
       sb.append(eol);
     }
-    firstGroup.set(true);
-    second.values().forEach(consumer);
+    emitSection(sb, second, second == staticImports, eol);
 
     // allImports.forEach(x -> System.out.print("-----\n" + x + "\n-----"));
     return sb.toString();
+  }
+
+  private void emitSection(StringBuilder sb, Map<Integer, ArrayList<Import>> section,
+      boolean isStaticSection, String eol) {
+    boolean separateGroups = !(isStaticSection && joinStaticGroups);
+    AtomicBoolean firstGroup = new AtomicBoolean(true);
+    section.values().forEach(grouping -> {
+      if (!firstGroup.getAndSet(false) && separateGroups) {
+        sb.append(eol);
+      }
+      grouping.forEach(imp -> sb.append(imp).append(eol));
+    });
   }
 
 }

--- a/src/main/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojo.java
+++ b/src/main/java/net/revelc/code/impsort/maven/plugin/AbstractImpSortMojo.java
@@ -112,6 +112,20 @@ abstract class AbstractImpSortMojo extends AbstractMojo {
   protected boolean joinStaticWithNonStatic;
 
   /**
+   * Allows omitting the blank lines between static-import sub-groups defined by
+   * <code>staticGroups</code>. When <code>true</code>, static imports are still ordered by their
+   * group prefixes but the resulting block is contiguous (no blank lines between sub-groups).
+   * Useful when an external linter (e.g. Checkstyle's <code>ImportOrder</code> with
+   * <code>option=top</code>) treats all static imports as a single group and rejects intra-group
+   * blank lines.
+   *
+   * @since 1.14.0
+   */
+  @Parameter(alias = "joinStaticGroups", property = "impsort.joinStaticGroups",
+      defaultValue = "false")
+  protected boolean joinStaticGroups;
+
+  /**
    * Project's main source directory as specified in the POM. Used by default if
    * <code>directories</code> is not set.
    *
@@ -285,7 +299,7 @@ abstract class AbstractImpSortMojo extends AbstractMojo {
 
     // process all found files, and aggregate any failures
     Grouper grouper = new Grouper(groups, staticGroups, staticAfter, joinStaticWithNonStatic,
-        breadthFirstComparator);
+        joinStaticGroups, breadthFirstComparator);
     Charset encoding = Charset.forName(sourceEncoding);
 
     LanguageLevel langLevel = getLanguageLevel(compliance, ignoreParseErrorsBelowImports);

--- a/src/test/java/net/revelc/code/impsort/ImpSortTest.java
+++ b/src/test/java/net/revelc/code/impsort/ImpSortTest.java
@@ -67,6 +67,28 @@ public class ImpSortTest {
   }
 
   @Test
+  public void testJoinStaticGroups() {
+    String eol = "\n";
+    List<Import> imports =
+        List.of(new Import(true, "java.util.Objects.requireNonNull", "", "", eol),
+            new Import(true, "com.google.common.base.Preconditions.checkArgument", "", "", eol),
+            new Import(false, "java.util.List", "", "", eol),
+            new Import(false, "com.google.common.collect.ImmutableList", "", "", eol));
+
+    Grouper separated = new Grouper("java.,com.", "java.,com.", false, false, false, false);
+    assertEquals("import static java.util.Objects.requireNonNull;\n" + "\n"
+        + "import static com.google.common.base.Preconditions.checkArgument;\n" + "\n"
+        + "import java.util.List;\n" + "\n" + "import com.google.common.collect.ImmutableList;\n",
+        separated.groupedImports(imports, eol));
+
+    Grouper joined = new Grouper("java.,com.", "java.,com.", false, false, true, false);
+    assertEquals("import static java.util.Objects.requireNonNull;\n"
+        + "import static com.google.common.base.Preconditions.checkArgument;\n" + "\n"
+        + "import java.util.List;\n" + "\n" + "import com.google.common.collect.ImmutableList;\n",
+        joined.groupedImports(imports, eol));
+  }
+
+  @Test
   public void testBreadthFirstComparator() {
     TreeSet<Import> set = addTestImportsForSort(Grouper.breadthFirstComparator);
     assertArrayEquals(


### PR DESCRIPTION
Allows omitting blank lines between static-import sub-groups when staticGroups defines multiple prefixes. Useful for compatibility with linters (e.g. Checkstyle ImportOrder with option=top) that treat all static imports as a single group and reject intra-group blank lines.